### PR TITLE
enable command to delete tag

### DIFF
--- a/lib/AtomicParsley/Command.pm
+++ b/lib/AtomicParsley/Command.pm
@@ -7,7 +7,7 @@ package AtomicParsley::Command;
 # ABSTRACT: Interface to the Atomic Parsley command
 
 use AtomicParsley::Command::Tags;
-use IPC::Cmd '0.72', ();
+use IPC::Cmd '0.76', ();
 use File::Spec '3.33';
 use File::Copy;
 
@@ -75,6 +75,8 @@ sub write_tags {
 # Run the command
 sub _run {
     my ( $self, $cmd ) = @_;
+
+    local $IPC::Cmd::ALLOW_NULL_ARGS = 1;
 
     my ( $success, $error_message, $full_buf, $stdout_buf, $stderr_buf ) =
       IPC::Cmd::run( command => $cmd, verbose => $self->{'verbose'} );

--- a/lib/AtomicParsley/Command/Tags.pm
+++ b/lib/AtomicParsley/Command/Tags.pm
@@ -5,8 +5,6 @@ package AtomicParsley::Command::Tags;
 
 # ABSTRACT: represent the mp4 metatags
 
-use Params::Util qw{_STRING};
-
 use Object::Tiny qw{
   artist
   title
@@ -48,7 +46,7 @@ sub prepare {
     # loop through all accessors and generate parameters for AP
     my @out;
     while ( my ( $key, $value ) = each(%$self) ) {
-        next unless _STRING($value);
+        next unless( defined $value );
 
         push @out, "--$key";
         push @out, $value;

--- a/t/05_tags.t
+++ b/t/05_tags.t
@@ -15,11 +15,12 @@ my $tags = new_ok(
         artist  => 'foo',
         title   => 'bar',
         album   => '',
-        genre   => {},
-        disk    => [],
-        comment => (),
+#        genre   => {},
+#        disk    => [],
+#        comment => (),
+        comment => undef,
     ]
 );
 
 my @p = $tags->prepare;
-cmp_bag( \@p, [ '--artist', 'foo', '--title', 'bar' ] );
+cmp_bag( \@p, [ '--artist', 'foo', '--title', 'bar', '--album', '' ] );

--- a/t/11_command.t
+++ b/t/11_command.t
@@ -1,0 +1,34 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+use FindBin qw($Bin);
+
+use AtomicParsley::Command::Tags;
+use AtomicParsley::Command;
+
+my $ap = AtomicParsley::Command->new;
+my $tags;
+my $testfile = "$Bin/resources/Family.mp4";
+
+# read_tags from tempfile that contains title, artist and genre
+my $read_tags = $ap->read_tags($testfile);
+
+# update
+my $write_tags = AtomicParsley::Command::Tags->new(
+    title   => '',
+    artist  => ' ',
+    genre   => undef,
+    );
+my $new_file = $ap->write_tags( $testfile, $write_tags );
+
+# and read 
+my $new_tags = $ap->read_tags($new_file);
+is( $new_tags->title, undef, 'removed' );
+is( $new_tags->artist, ' ', 'modified' );
+is( $new_tags->genre, 'Comedy', 'kept' );
+
+unlink $new_file;
+ok( !-e $new_file );


### PR DESCRIPTION
Hi, 

IPC::Cmd allows null value of parameter from the version 0.76.
By this, it can dictate deletion of tags to AtomicParsley.

Please merge my commit(s) if it is not an imposition.
Best regards.
