### PR TITLE
Use `bsd_glob` for temp file finding

### DIFF
--- a/lib/AtomicParsley/Command.pm
+++ b/lib/AtomicParsley/Command.pm
@@ -10,6 +10,7 @@ use AtomicParsley::Command::Tags;
 use IPC::Cmd '0.76', ();
 use File::Spec '3.33';
 use File::Copy;
+use File::Glob qw{ bsd_glob };
 
 sub new {
     my $class = shift;
@@ -214,7 +215,7 @@ sub _get_temp_file {
     my $suffix = $1;
 
     # search directory
-    for my $tempfile ( glob("$directories*$suffix") ) {
+    for my $tempfile ( bsd_glob("$directories*$suffix") ) {
 
         # return the first match
         if ( $tempfile =~ /^$directories$file.*$suffix$/ ) {

--- a/t/10_command.t
+++ b/t/10_command.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Test::Fatal;
-use Test::More tests => 18;
+use Test::More tests => 23;
 use FindBin qw($Bin);
 use File::Copy;
 
@@ -87,6 +87,18 @@ ok( -e $tempfile );
 my $read_tags = $ap->read_tags($tempfile);
 is_deeply( $read_tags, $write_tags, 'read/write tags' );
 
+#-- test with spaces for file glob
+mkdir "$Bin/space in resources";
+my $testfile3 = "$Bin/space in resources/Family with spaces.mp4";
+copy( $testfile, $testfile3 );
+
+my $return_file = $ap->write_tags( $testfile3, $write_tags, 1 );
+ok( -e $return_file );
+ok ( $return_file eq $testfile3);
+$read_tags = $ap->read_tags($return_file);
+is ($read_tags->title, $write_tags->title, "returned file has tags" );
+
+
 # remove tags, and test replace
 my $testfile2 = "$Bin/resources/Family-replace.mp4";
 copy( $testfile, $testfile2 );
@@ -99,6 +111,7 @@ is( $tempfile2, $testfile2 );
 $read_tags = $ap->read_tags($tempfile2);
 is( $read_tags->title, undef,    'removed' );
 is( $read_tags->genre, 'Comedy', 'kept' );
+
 
 $ap->read_tags('/does/not/exist');
 ok( !$ap->{success} );
@@ -115,3 +128,7 @@ unlink $tempfile;
 ok( !-e $tempfile );
 unlink $tempfile2;
 ok( !-e $tempfile2 );
+unlink $testfile3;
+ok( !-e $tempfile2 );
+rmdir "$Bin/space in resources";
+ok( !-d "$Bin/space in resources");


### PR DESCRIPTION
If the `$replace` option is used, the file glob fails when the path has
a space in it. The glob splits paths with spaces, and then the glob
values don't match to the regex attempting to match temporary files.

Use the `File::Glob {bsd_glob}` to do globs for files with spaces in
the path. For example, the file `/Volumes/Media/TV shows/Downton
Abbey.SE01E01.mp4` would return a glob of `{ "/Volumes/Media/TV",
"Shows/Downton", "Abbey.SE01E01.mp4" }` and not match to the 
temp regex of `if ( $tempfile =~ /^$directories$file.*$suffix$/ `

Unit test copies the `.mp4` file to a path with a space in it, and tests
that the set tags can be read back. If the temp file *does not*
replace the original the file won't have tags set.