### PR TITLE
fix version requirement to use correct syntax

### DIFF
--- a/lib/AtomicParsley/Command.pm
+++ b/lib/AtomicParsley/Command.pm
@@ -7,8 +7,8 @@ package AtomicParsley::Command;
 # ABSTRACT: Interface to the Atomic Parsley command
 
 use AtomicParsley::Command::Tags;
-use IPC::Cmd '0.76', ();
-use File::Spec '3.33';
+use IPC::Cmd 0.76 ();
+use File::Spec 3.33;
 use File::Copy;
 use File::Glob qw{ bsd_glob };
 

--- a/t/10_command.t
+++ b/t/10_command.t
@@ -7,7 +7,7 @@ use Test::Fatal;
 use Test::More;
 use FindBin qw($Bin);
 use File::Copy;
-use IPC::Cmd '0.76', ();
+use IPC::Cmd 0.76 ();
 
 use AtomicParsley::Command::Tags;
 


### PR DESCRIPTION
Version numbers on a use line need to be unquoted to be handled properly. When they are quoted, they are passed in import instead. Part versions of perl ignored these arguments, but future versions are intending to throw errors for arguments given to an undefined import method.